### PR TITLE
StimoMC.com -> StimoMC.net

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -34,7 +34,7 @@ The good news is that anyone can add their server to the list themselves! Instru
 | ZeferaMC              | [zeferamc.com](https://pack.bedrockhub.io/bedrockconnect)           |
 | Syodo                 | [syodo.xyz](https://pack.bedrockhub.io/bedrockconnect)              |
 | RusherVace            | [play.rushervace.net](https://pack.bedrockhub.io/bedrockconnect)    | 
-| StimoMC               | [stimomc.com](https://pack.bedrockhub.io/bedrockconnect)            |  
+| StimoMC               | [stimomc.net](https://pack.bedrockhub.io/bedrockconnect)            |  
 
 
 ## Own Pack

--- a/serverlist.json
+++ b/serverlist.json
@@ -322,7 +322,7 @@
   {
     "displayName": "StimoMC",
     "packName": "bedrockconnect",
-    "ip": "stimomc.com",
+    "ip": "stimomc.net",
     "port": 19132,
     "featured": false,
     "partner": false


### PR DESCRIPTION
The domain(s) StimoMC.com, StimoMC.eu & StimoMC.de will no longer be supported from the next few days and StimoMC will only be available at StimoMC.net.